### PR TITLE
CBBD-141: Increase Wildfly connect timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Ignore Maven output folders
 /target*/
+
+# The Derby driver writes out these obnoxious files even when it's not being used.
+*/derby.log

--- a/bbonfhir-server-app/src/main/config/server-stop.sh
+++ b/bbonfhir-server-app/src/main/config/server-stop.sh
@@ -3,6 +3,7 @@
 # Constants.
 serverVersion='8.1.0.Final'
 serverInstall="wildfly-${serverVersion}"
+serverConnectTimeoutMilliseconds=$((30 * 1000))
 
 # Calculate the directory that this script is in.
 scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -36,6 +37,7 @@ serverLogRun="${directory}/${serverInstall}/server-console.log"
 serverLogStop="${directory}/${serverInstall}/server-stop.log"
 "${directory}/${serverInstall}/bin/jboss-cli.sh" \
 	--connect \
+	--timeout=${serverConnectTimeoutMilliseconds} \
 	--command=shutdown \
 	&> "${serverLogStop}"
 


### PR DESCRIPTION
This seems to have been the root cause of [CBBD-141: Intermittent benchmark failure due to JBoss/Wildfly connect timeouts](http://issues.hhsdevcloud.us/browse/CBBD-141), and isn't a bad idea, regardless.