### PR TITLE
Fixed bug in server-start.sh, where it called wrong -stop.sh on error.

### DIFF
--- a/bbonfhir-server-app/src/main/config/server-start.sh
+++ b/bbonfhir-server-app/src/main/config/server-start.sh
@@ -145,7 +145,7 @@ while true; do
 	fi
 	if [[ $SECONDS -gt $endSeconds ]]; then
 		>&2 echo "Error: Server failed to start within ${serverTimeoutSeconds} seconds. Trying to stop it..."
-		"${scriptDirectory}/bluebutton-server-app-server-stop.sh" --directory "${directory}"
+		"${scriptDirectory}/bbonfhir-server-app-server-stop.sh" --directory "${directory}"
 		exit 3
 	fi
 	sleep 1


### PR DESCRIPTION
Somewhat related to CBBD-138, as it was annoying me while I worked on it, but mostly just an unrelated bug that needed to be stomped. Should prevent us from having to restart build server every time an IT fails.